### PR TITLE
Fixed save_panda_results in panda.py

### DIFF
--- a/netZooPy/panda/panda.py
+++ b/netZooPy/panda/panda.py
@@ -394,7 +394,7 @@ class Panda(object):
     def save_panda_results(self, path='panda.npy'):
         with Timer('Saving PANDA network to %s ...' % path):
             #Because there are two modes of operation (save_memory), save to file will be different
-            if hasattr(self,'panda_network'):
+            if not hasattr(self,'export_panda_results'):
                 toexport = self.panda_network
             else:
                 toexport = self.export_panda_results


### PR DESCRIPTION
In file panda.py at line 397 I substituted 
`if hasattr(self,'panda_network')` 
with 
`if not hasattr(self,'export_panda_results')`.

With the first statement, we always save the network matrix, regardless the `save_memory` attribute.
Checking if `export_panda_results` is not present solved the issue.