### PR TITLE
Important fix when storing TFCoopDiag

### DIFF
--- a/netZooPy/puma/calculations.py
+++ b/netZooPy/puma/calculations.py
@@ -62,7 +62,7 @@ def compute_puma_cpu(
         ppi_matrix += alpha * ppi
 
         # Alessandro
-        TFCoopDiag = ppi_matrix.diagonal()
+        TFCoopDiag = ppi_matrix.diagonal().copy()
         ppi_matrix[s1] = TFCoopInit[s1]
         ppi_matrix[:, s1] = TFCoopInit[:, s1]
         np.fill_diagonal(ppi_matrix, TFCoopDiag)


### PR DESCRIPTION
It's necessary to have a .copy() when creating TFCoopDiag. Otherwise it's just a pointer and it gets modified with the whole matrix. Now the python and Matlab outputs coincide :)