### PR TITLE
Fixes to GPU computation of PANDA and saving of LIONESS aggregate net…

### DIFF
--- a/netZooPy/lioness/lioness.py
+++ b/netZooPy/lioness/lioness.py
@@ -175,7 +175,7 @@ class Lioness(Panda):
                 total_genes = [i for i in gene_names for _ in range(len(tf_names))]
                 indDF = pd.DataFrame([total_tfs, total_genes], index=["tf", "gene"])
                 indDF = indDF.append(
-                    pd.DataFrame(self.total_lioness_network, index = self.expression_samples)
+                    pd.DataFrame(self.total_lioness_network.transpose(), index = self.expression_samples)
                 ).transpose()
             else:  # if equal to None to be specific
                 total_genes1 = gene_names * len(gene_names)

--- a/netZooPy/panda/calculations_gpu.py
+++ b/netZooPy/panda/calculations_gpu.py
@@ -80,7 +80,7 @@ def compute_panda_gpu(
     motif_matrix = cp.array(motif_matrix)
     correlation_matrix = cp.array(correlation_matrix)
 
-    if hamming > 0.001:
+    while hamming > threshold:
 
         W = 0.5 * (
             gt_function(ppi_matrix, motif_matrix)
@@ -104,6 +104,8 @@ def compute_panda_gpu(
         # del W, ppi, motif  # release memory for next step
         print("step: {}, hamming: {}".format(step, hamming))
         step = step + 1
+        
+        del W, ppi, motif  # release memory for next step
 
     motif_matrix = cp.asnumpy(motif_matrix)
     return motif_matrix


### PR DESCRIPTION
While running PANDA/LIONESS with the newest version of NetZooPy, I have noticed that the GPU computation of PANDA networks is flawed - probably as a result of attempted refactoring, the PANDA loop will only run once (which is, of course, generally insufficient for convergence). I have also noticed a less critical issue where the attempt to save the aggregate LIONESS network at the end of the computation fails and I have also fixed that. I am happy to provide more details but I believe the fixes are pretty straightforward.

Ladislav