### PR TITLE
PANDA- adding guard against invalid gene IDs and test case.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.1
+current_version = 0.10.2
 commit = True
 
 [bumpversion:file:setup.py]

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Please report any issues to the [issues page](https://github.com/netZoo/netZooPy
 
 Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
 
-Latest version: 0.10.1
+Latest version: 0.10.2

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: netzoopy
-  version: 0.10.1
+  version: 0.10.2
 
 source:
   path: ..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ copyright = u'2019, netZoo'
 author    = u'netZoo'
 
 # The short X.Y version
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 version     = ".".join(__version__.split(".")[:2])
 # The full version, including alpha/beta/rc tags
 release     = __version__

--- a/netZooPy/__init__.py
+++ b/netZooPy/__init__.py
@@ -7,4 +7,4 @@ from netZooPy import lioness
 from netZooPy import condor
 from netZooPy import sambar
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/netZooPy/panda/panda.py
+++ b/netZooPy/panda/panda.py
@@ -539,6 +539,11 @@ class Panda(object):
             commind1 = ~np.isnan(idx_tfs) & ~np.isnan(idx_genes)
             idx_tfs = [i for (i, v) in zip(idx_tfs, commind1) if v]
             idx_genes = [i for (i, v) in zip(idx_genes, commind1) if v]
+            if (len(idx_genes) == 0) or (len(idx_tfs)):
+                raise Exception('Error when creating the motif network!'
+                             ' Typically this exception is raised if your'
+                             ' expression matrix genes and motif priors'
+                             ' not have any intersection.')
             idx = np.ravel_multi_index(
                 (idx_tfs, idx_genes), self.motif_matrix_unnormalized.shape
             )

--- a/netZooPy/panda/panda.py
+++ b/netZooPy/panda/panda.py
@@ -539,7 +539,7 @@ class Panda(object):
             commind1 = ~np.isnan(idx_tfs) & ~np.isnan(idx_genes)
             idx_tfs = [i for (i, v) in zip(idx_tfs, commind1) if v]
             idx_genes = [i for (i, v) in zip(idx_genes, commind1) if v]
-            if (len(idx_genes) == 0) or (len(idx_tfs)):
+            if (len(idx_genes) == 0) or (len(idx_tfs) == 0):
                 raise Exception('Error when creating the motif network!'
                              ' Typically this exception is raised if your'
                              ' expression matrix genes and motif priors'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='netZooPy',
-    version='0.10.1',
+    version='0.10.2',
     description='Python implementation of netZoo.',
     url='https://github.com/netZoo/netZooPy',
     author='netZoo team',

--- a/tests/test_panda.py
+++ b/tests/test_panda.py
@@ -1,4 +1,3 @@
-from re import U
 import pytest
 import os
 from netZooPy.panda.panda import Panda

--- a/tests/test_panda.py
+++ b/tests/test_panda.py
@@ -1,3 +1,4 @@
+from re import U
 import pytest
 import os
 from netZooPy.panda.panda import Panda
@@ -343,3 +344,66 @@ def test_panda():
     assert(np.allclose(W_gt, W_res, rtol=1e-05, atol=1e-08))
 
 
+def test_incorrect_gene_ids_raises_exception():
+    '''
+    This test checks that an appropriately descriptive exception
+    is raised if one attempts to run PANDA on an expression matrix
+    that does not have genes intersecting with those in the motif
+    prior matrix
+    '''
+
+    # these numbers are arbitrary but don't need to be large
+    # to trigger the exception since it would be raised prior
+    # to any Panda iterations.
+    num_genes = 20 # number of genes in the expression mtx
+    num_samples = 30 # number of samples in the expression mtx
+    num_tfs = 10 # number of transcription factors in the motif prior
+    num_motif_genes = 10 # number of genes in the motif prior
+
+    # create a dataframe of mock expression data
+    exp_mtx_genes = [f'g{_}' for _ in range(num_genes)]
+    exp_mtx_samples = [f's{_}' for _ in range(num_samples)]
+    expression_data = pd.DataFrame(
+        np.random.randint(0, 100, size=(num_genes, num_samples)),
+        index=exp_mtx_genes,
+        columns=exp_mtx_samples
+    )
+
+    # mock motif prior. Note that the genes (2nd col) start with 'G'
+    # instead of 'g' in the expression matrix
+    tf_list = [f'tf{_}' for _ in range(num_tfs)]
+    motif_gene_list = [f'G{_}' for _ in range(num_motif_genes)]
+    motif_data = pd.DataFrame(
+        {
+            0: np.repeat(tf_list, num_motif_genes),
+            1: np.tile(motif_gene_list, num_tfs),
+            2: np.random.random(num_tfs*num_motif_genes)
+        }
+    )
+
+    # mock ppi prior
+    ppi_data = pd.DataFrame(
+        {
+            0: np.repeat(tf_list, num_tfs),
+            1: np.tile(tf_list, num_tfs),
+            2: np.random.random(num_tfs**2)
+        }
+    )
+
+    with pytest.raises(Exception,
+                       match='Error when creating the motif network!.*'):
+        panda_obj1 = Panda(
+            expression_data,
+            motif_data,
+            ppi_data,
+            modeProcess='legacy'
+        )
+
+    with pytest.raises(Exception,
+                       match='Error when creating the motif network!.*'):
+            panda_obj2 = Panda(
+            expression_data,
+            motif_data,
+            ppi_data,
+            modeProcess='intersection'
+        )


### PR DESCRIPTION
To address https://github.com/netZoo/netZooPy/issues/341

Note that the original issue is only raised when the `modeProcess` arg to the `Panda` constructor is either `legacy` or `intersection`.

For the default of `modeProcess='union'`, there is apparently no problem (i.e. no errors/exceptions) even if the expression matrix genes do not have any intersection with the motif priors. Unsure if that's an issue, or whether that just triggers a trivial run (i.e. there is no corresponding gene expression data so the iterative looping performs no updates)? If so, maybe a warning should be generated?