### PR TITLE
changed tmp file write location

### DIFF
--- a/netZooPy/panda/panda.py
+++ b/netZooPy/panda/panda.py
@@ -179,9 +179,9 @@ class Panda(object):
             with Timer("Saving expression matrix and normalized networks ..."):
                 os.makedirs('./tmp',exist_ok=True) 
                 if self.expression_data is not None:
-                    np.save("/tmp/expression.npy", self.expression_data.values)
-                np.save("/tmp/motif.normalized.npy", self.motif_matrix)
-                np.save("/tmp/ppi.normalized.npy", self.ppi_matrix)
+                    np.save("./tmp/expression.npy", self.expression_data.values)
+                np.save("./tmp/motif.normalized.npy", self.motif_matrix)
+                np.save("./tmp/ppi.normalized.npy", self.ppi_matrix)
 
         # delete expression data
         del self.expression_data


### PR DESCRIPTION
Previously the code created a ./tmp folder, but then wrote the files into the /tmp folder instead. This creates an issue when multiple users share the same environment like on a server. One user can write to /tmp, but then another user who is also running PANDA/LIONESS does not have permission to overwrite their file