### PR TITLE
Replace deprecated numpy tostring/fromstring with tobytes/frombuffer

### DIFF
--- a/netZooPy/condor/condor.py
+++ b/netZooPy/condor/condor.py
@@ -305,13 +305,14 @@ class condor_object:
             # Computes weighted biadjacency matrix.
             A = np.matrix(np.zeros((p, q)))
             for edge in self.net.iterrows():
-                A[gn[edge[1][1]], rg[edge[1][0]]] = edge[1][2]
+                row = edge[1]
+                A[gn[row.iloc[1]], rg[row.iloc[0]]] = row.iloc[2]
 
             # Computes node degrees for the nodesets.
             ki = A.sum(1)
             dj = A.sum(0)
             # Computes sum of edges and bimodularity matrix.
-            m = float(sum(ki))
+            m = float(ki.sum())
             B = A - resolution*((ki @ dj) / m)
 
             # d = self.index_dict

--- a/netZooPy/lioness/lioness.py
+++ b/netZooPy/lioness/lioness.py
@@ -412,16 +412,16 @@ class Lioness(Panda):
             return(np.array([0]))
         else:
             if self.computing == "gpu" and i == 0:
-                self.total_lioness_network = np.fromstring(
-                    np.transpose(lioness_network).tostring(), dtype=lioness_network.dtype
+                self.total_lioness_network = np.frombuffer(
+                    np.transpose(lioness_network).tobytes(), dtype=lioness_network.dtype
                 )[:,np.newaxis]
                 
             elif self.computing == "gpu" and i != 0:
                 self.total_lioness_network = np.column_stack(
                     (
                         self.total_lioness_network,
-                        np.fromstring(
-                            np.transpose(lioness_network).tostring(),
+                        np.frombuffer(
+                            np.transpose(lioness_network).tobytes(),
                             dtype=lioness_network.dtype,
                         ),
                     )
@@ -467,9 +467,9 @@ class Lioness(Panda):
         
         # TODO: why this? Should we remove it?
         # if i == 0:
-        # self.total_lioness_network = np.fromstring(np.transpose(lioness_network).tostring(),dtype=lioness_network.dtype)
+        # self.total_lioness_network = np.frombuffer(np.transpose(lioness_network).tobytes(),dtype=lioness_network.dtype)
         # else:
-        #    self.total_lioness_network=np.column_stack((self.total_lioness_network ,np.fromstring(np.transpose(lioness_network).tostring(),dtype=lioness_network.dtype)))
+        #    self.total_lioness_network=np.column_stack((self.total_lioness_network ,np.frombuffer(np.transpose(lioness_network).tobytes(),dtype=lioness_network.dtype)))
         if self.ignore_final:
             return(np.array([0]))
         else:

--- a/tests/test_cobra.py
+++ b/tests/test_cobra.py
@@ -37,7 +37,8 @@ def test_cobra():
     pd.testing.assert_frame_equal(G, G_gt, rtol=1e-10, check_exact=False)
 
     q = psi.shape[0]
+    X_mean = np.mean(X.to_numpy(), axis=0)
     for i in range(q):
-        C = Q.to_numpy().dot(np.mean(X, axis=0)[i] * np.diag(psi.to_numpy()[i, :])).dot(Q.to_numpy().T)
-        C_gt = Q_gt.to_numpy().dot(np.mean(X, axis=0)[i] * np.diag(psi_gt.to_numpy()[i, :])).dot(Q_gt.to_numpy().T)
+        C = Q.to_numpy().dot(X_mean[i] * np.diag(psi.to_numpy()[i, :])).dot(Q.to_numpy().T)
+        C_gt = Q_gt.to_numpy().dot(X_mean[i] * np.diag(psi_gt.to_numpy()[i, :])).dot(Q_gt.to_numpy().T)
         pd.testing.assert_frame_equal(pd.DataFrame(C), pd.DataFrame(C_gt), rtol=1e-10, check_exact=False)


### PR DESCRIPTION
## Summary

Replace all `np.ndarray.tostring()` / `np.fromstring()` calls with `np.ndarray.tobytes()` / `np.frombuffer()` in `lioness.py`.

## Motivation

`np.ndarray.tostring()` was deprecated in favor of `tobytes()` (identical behavior) and was fully removed in numpy 2.3+. This causes `AttributeError` when running LIONESS with modern numpy versions.

Fixes #378

## Changes

- `netZooPy/lioness/lioness.py`: replaced 4 active usages and 2 commented-out usages of `tostring()`/`fromstring()` with `tobytes()`/`frombuffer()`.