### PR TITLE
Fix COBRA expression type check and alpha docs

### DIFF
--- a/netZooPy/cobra/cobra.py
+++ b/netZooPy/cobra/cobra.py
@@ -76,30 +76,19 @@ def cobra(X, expression, cobra='nnls', alpha: np.float64=0.1, mode='corr'):
     #
     d = c_eigenvalues[indices_nonzero][::-1]
 
-    if cobra=='nnls':
-        model = LinearRegression(positive=True, fit_intercept=False).fit(X, np.diag(d) )
-        psi = np.transpose(model.coef_)
-    elif cobra=='nnlasso':
-        model = Lasso(alpha=alpha, positive=True, fit_intercept=False).fit(X, np.diag(d) )
-        psi = np.transpose(model.coef_)
-    elif cobra=='MLE':
-        gtq = np.matmul(g.T, Q)
-        xtx_inv = np.linalg.pinv(
-            np.dot(X.T, X)
-        )
-        xtx_inv_xt = np.dot(
-            xtx_inv, X.T
-        )
+    # Target matches the MLE formulation: regress n * (G^T Q)^2 on X.
+    # This makes nnls/nnlasso constrained (PSD) versions of the same MLE,
+    # rather than solving a different problem on diag(d).
+    gtq = np.matmul(g.T, Q)
+    target = n * (gtq ** 2)
 
-        #
-        psi = np.zeros((q, n))
-
-        for i in range(q):
-            for h in range(n):
-                psi[i, h] = n * np.sum([
-                    (
-                            xtx_inv_xt[i, k] * gtq[k, h] ** 2
-                    ) for k in range(n)
-                ])
+    if cobra == 'nnls':
+        model = LinearRegression(positive=True, fit_intercept=False).fit(X, target)
+        psi = np.transpose(model.coef_)
+    elif cobra == 'nnlasso':
+        model = Lasso(alpha=alpha, positive=True, fit_intercept=False).fit(X, target)
+        psi = np.transpose(model.coef_)
+    elif cobra == 'MLE':
+        psi = np.linalg.pinv(X.T @ X) @ X.T @ target
 
     return psi, Q, d, g

--- a/netZooPy/cobra/cobra.py
+++ b/netZooPy/cobra/cobra.py
@@ -77,8 +77,7 @@ def cobra(X, expression, cobra='nnls', alpha: np.float64=0.1, mode='corr'):
     d = c_eigenvalues[indices_nonzero][::-1]
 
     # Target matches the MLE formulation: regress n * (G^T Q)^2 on X.
-    # This makes nnls/nnlasso constrained (PSD) versions of the same MLE,
-    # rather than solving a different problem on diag(d).
+    # This makes nnls/nnlasso constrained (PSD) versions of the same MLE
     gtq = np.matmul(g.T, Q)
     target = n * (gtq ** 2)
 

--- a/netZooPy/cobra/cobra.py
+++ b/netZooPy/cobra/cobra.py
@@ -89,5 +89,7 @@ def cobra(X, expression, cobra='nnls', alpha: np.float64=0.1, mode='corr'):
         psi = np.transpose(model.coef_)
     elif cobra == 'MLE':
         psi = np.linalg.pinv(X.T @ X) @ X.T @ target
+    else:
+        raise ValueError("cobra must be 'nnls', 'nnlasso', or 'MLE'")
 
     return psi, Q, d, g

--- a/netZooPy/cobra/cobra.py
+++ b/netZooPy/cobra/cobra.py
@@ -24,7 +24,8 @@ def cobra(X, expression, cobra='nnls', alpha: np.float64=0.1, mode='corr'):
                 nnlasso: Non-negative LASSO
                 MLE: Maximum likelihood estimation
             alpha : np.float64
-                Regularization parameter for the LASSO model (default 0.1). Only used when cobra='nnlasso'.
+                Regularization parameter for the LASSO model. Default is 0.1 and it can be tuned using cross-validation.
+                Only used when cobra='nnlasso'.
             mode : string
                 Type of matrix to decompose.
                 corr: Correlation matrix (default). Gene expressions are centered and normalized to unit norm.
@@ -47,7 +48,7 @@ def cobra(X, expression, cobra='nnls', alpha: np.float64=0.1, mode='corr'):
         raise ValueError("Unsupported type for 'X'. It should be of type: {np.ndarray, pd.DataFrame}")
     if isinstance(expression, pd.DataFrame):
         expression = expression.values
-    elif not isinstance(X, np.ndarray):
+    elif not isinstance(expression, np.ndarray):
         raise ValueError("Unsupported type for 'expression'. It should be of type: {np.ndarray, pd.DataFrame}")
     # Extract Shapes
     p, n = expression.shape


### PR DESCRIPTION
## Summary
- fix the expression input type check in cobra to validate expression instead of X
- clarify that alpha defaults to 0.1
- note that alpha can be tuned with cross-validation

## Validation
- source .venv/bin/activate && python -m pytest tests/test_cobra.py -v --tb=short