### PR TITLE
Fix COBRA install: add scikit-learn dependency + revamp install docs (#391)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Upon completion you can load netZooPy in your python code through
 
 ```python
 import netZooPy
+from netZooPy.cobra import cobra
 ```
 
 ## Conda installation

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,41 +1,82 @@
 # Installation guide
 
-You can install netZooPy through pip or through conda. Below, you will find 
+You can install netZooPy through pip or through conda. Below, you will find
 all the steps and requirements for both cases.
 
 ## PIP installation
 
 ### Requirements
 
-- Python 3
+netZooPy requires Python 3. `pip` installs the following dependencies
+automatically, so you normally do not need to install them by hand:
 
-In addition to the following pip packages:
-
-- networkx
-
-- numpy
-
+- h5py
 - pandas
-
+- numpy
+- networkx
 - matplotlib
-
 - scipy
-
 - python-igraph
+- joblib
+- statsmodels
+- scikit-learn
+- click
+- tables (PyTables)
+- torch (PyTorch)
+
+GPU acceleration (the `gpu` computing option in PANDA, LIONESS, PUMA and OTTER)
+additionally requires [CuPy](https://cupy.dev). CuPy is **not** installed
+automatically because the right build depends on your CUDA version — install
+the one that matches your toolkit, e.g. `pip install cupy-cuda12x`.
 
 ### Install
 
-- `git clone https://github.com/netZoo/netZooPy.git`
+We recommend installing netZooPy inside a dedicated virtual environment so it
+stays isolated from your other projects:
 
-- `cd netZooPy`
+```bash
+python3 -m venv netzoo-env
+source netzoo-env/bin/activate          # Windows: netzoo-env\Scripts\activate
+git clone https://github.com/netZoo/netZooPy.git
+cd netZooPy
+pip3 install -e .
+```
 
-- `pip3 install -e .`
+Then you can import netZooPy and its modules in your code:
 
-- Then you can import netZooPy in your code through `import netZooPy`
+```python
+import netZooPy
+from netZooPy.cobra import cobra
+```
 
 ### Troubleshooting
 
-- To report any installation issue or function bug, please report through opening an [issue](https://github.com/netZoo/netZooPy/issues) on github.
+**`import netZooPy` works but a submodule import fails** — for example
+`from netZooPy.cobra import cobra` raises
+`ModuleNotFoundError: No module named 'netZooPy.cobra'`, or you see
+`ImportError: cannot import name 'cobra' from 'netZooPy' (unknown location)`.
+
+This means Python is importing the cloned *source folder* instead of the
+installed package. It usually happens when:
+
+- you start Python (or a Jupyter / VS Code notebook kernel) from the directory
+  that *contains* the cloned `netZooPy` folder — the folder name then shadows
+  the installed package as an empty namespace package; or
+- the active interpreter / kernel is not the same environment where you ran
+  `pip3 install -e .` (a common mismatch in VS Code and Jupyter).
+
+Quick check: run `python -c "import netZooPy; print(netZooPy.__file__)"`. If it
+prints `None`, you are loading the empty namespace folder rather than the
+package. To fix it, make sure your interpreter / notebook kernel is the
+environment where netZooPy is installed, and start Python from a directory
+other than the one containing the clone.
+
+**`ModuleNotFoundError: No module named 'sklearn'`** when importing COBRA means
+scikit-learn is missing. Update to the latest netZooPy (scikit-learn is now a
+declared dependency) or install it manually with `pip install scikit-learn`.
+
+For any other installation issue or function bug, please open an
+[issue](https://github.com/netZoo/netZooPy/issues) on GitHub.
 
 
 ## Conda installation

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='netZooPy',
     'igraph',
     'joblib>=1.1.0',
     'statsmodels>=0.12.2',
+    'scikit-learn',
     'click',
     'tables',
     'torch'


### PR DESCRIPTION
Fixes #391.

### Problem
A user following the documented install (`git clone` → `cd netZooPy` → `pip3 install -e .`) could not run COBRA.

`netZooPy/cobra/cobra.py` imports `from sklearn.linear_model import LinearRegression, Lasso`, but `setup.py` did **not** list `scikit-learn` in `install_requires` (it was only in `requirements.txt`). Because `netZooPy/__init__.py` eagerly runs `from netZooPy import cobra`, a clean `pip install -e .` left **`import netZooPy` itself** broken with `ModuleNotFoundError: No module named 'sklearn'`, not just COBRA.

Separately, the reporter's `No module named 'netZooPy.cobra'` / `(unknown location)` errors come from an environment pitfall: running Python from the clone's parent directory (or a Jupyter/VS Code kernel that isn't the install env) makes the cloned `netZooPy` folder resolve as an empty namespace package that shadows the installed one.

### Changes
- **setup.py:** add `scikit-learn` to `install_requires` (the substantive fix).
- **README.md:** keep it minimal — only adds `from netZooPy.cobra import cobra` to the usage example.
- **docs/install/index.md:** revamp the install guide —
  - sync the dependency list with `setup.py` (was missing h5py, joblib, statsmodels, scikit-learn, click, tables, torch) and note pip installs them automatically; document CuPy as the optional GPU dependency;
  - recommend a virtual environment;
  - expand the Troubleshooting section to cover both failure modes above.

Troubleshooting content lives in the install guide (where users look) rather than the README.

### Verification
- Clean `python -m venv` + `pip install -e .` now auto-installs scikit-learn; `import netZooPy` and `from netZooPy.cobra import cobra` both succeed; `cobra()` runs in `nnls` and `MLE` modes.
- `tests/test_cobra.py` passes.
- Audited every submodule's module-load-time imports: `scikit-learn` was the only undeclared **hard** dependency. `cupy` is correctly optional (lazy, GPU-only); `patsy` is guaranteed via `statsmodels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)