### PR TITLE
Add recipe/recipe.yaml to bumpversion (#377)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,3 +11,5 @@ commit = True
 [bumpversion:file:docs/conf.py]
 
 [bumpversion:file:conda/meta.yaml]
+
+[bumpversion:file:recipe/recipe.yaml]


### PR DESCRIPTION
Fixes #377.

### Problem
The issue asked to add the conda recipe to `.bumpversion.cfg`. The snippet in the issue body (`conda/meta.yaml`) had already been applied — but that file is the legacy conda-build recipe and **nothing uses it**. All three conda workflows (`test-conda-build`, `conda-publish`, `conda-publish-manual`) build with `rattler-build` from `recipe-path: recipe/`, so **`recipe/recipe.yaml`** is the recipe that actually ships, and it was not in the bumpversion config.

Result: every version bump updated the dead file and skipped the live one. That's exactly what happened on 2026-01-09 — the `0.10.9 → 0.11.0` bump missed `recipe/recipe.yaml`, it was patched by hand ("Update recipe.yaml"), and this issue was filed the same day.

### Change
One line in `.bumpversion.cfg`:
```
[bumpversion:file:recipe/recipe.yaml]
```

### Verification
- `bumpversion patch --dry-run` asserts all six target files contain the version string and would stage `recipe/recipe.yaml`.
- A real bump run in a scratch copy changed exactly 7 files (the cfg + 6 targets), one line each; `recipe/recipe.yaml` went `version: "0.11.0"` → `version: "0.11.1"` with its quotes preserved.
- Every target file has a single occurrence of the version string, so the plain literal replacement cannot touch unrelated text.

### Follow-up (not in this PR)
The `conda/` directory (`meta.yaml` + `conda_build_config.yaml` pinning Python 3.7–3.10) is dead — no workflow, doc, or file references it. Worth deleting along with its bumpversion entry in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)